### PR TITLE
#21 update warp menu to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#21] Update warp menu to v2.0.0
+- Make static asset urls dependent of the current dogu-version to invalidate caches
 
 ## [v1.26.1-2] - 2024-08-27
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,18 @@ LABEL maintainer="hello@cloudogu.com" \
       NAME="nginx-static" \
       VERSION="1.26.1-2"
 
-ENV WARP_MENU_VERSION=1.7.3 \
-    WARP_MENU_TAR_SHA256="b3ed4b50b1b9a739a4430d88975b5e3030c5e542c0739ed6b72d7eb8fd9a7b18" \
+ENV WARP_MENU_VERSION=2.0.0 \
+    WARP_MENU_TAR_SHA256="51a1010ec0f82b634999e48976d7fec98e6eb574a4401a841cd53f8cd0e14040" \
     CES_ABOUT_VERSION=0.2.2 \
     CES_ABOUT_TAR_SHA256="9926649be62d8d4667b2e7e6d1e3a00ebec1c4bbc5b80a0e830f7be21219d496" \
     CES_THEME_VERSION=v0.7.1 \
     CES_THEME_TAR_SHA256="201013e417aad19572df5c5f6f9fb7053323cadb0d555da55541b1d27c2ef699" \
     SERVICE_TAGS="webapp" \
     SERVICE_LOCATION="/" \
-    SERVICE_PASS="/"
+    SERVICE_PASS="/" \
+    # Used in template to invalidate caches - do not remove. The release script will auto update this line
+    VERSION="1.26.1-6"
+
 
 # Install required packages
 RUN apk upgrade \

--- a/batsTests/startup.bats
+++ b/batsTests/startup.bats
@@ -56,17 +56,19 @@ teardown() {
   assert_line "[nginx-static][startup] Test Message"
 }
 
-@test "configureWarpMenuJson - should call doguctl to template our file" {
+@test "configureWarpMenu - should call doguctl to template our file" {
   # given
   source /workspace/resources/startup.sh
+  doguctl() { echo "doguctl called with params [$*]"; }
   sed() { echo "sed called with params [$*]"; }
 
   # when
-  run configureWarpMenuJson
+  run configureWarpMenu
 
   # then
   assert_success
   assert_line "[nginx-static][startup] Configure warp menu..."
+  assert_line "doguctl called with params [template /var/www/html/warp/add-warp-menu.js.tpl /var/www/html/warp/add-warp-menu.js]"
   assert_line "sed called with params [-i s|/warp/menu.json|/warp/menu/menu.json|g /var/www/html/warp/warp.js]"
 }
 

--- a/integrationTests/cypress/support/step_definitions/then.ts
+++ b/integrationTests/cypress/support/step_definitions/then.ts
@@ -1,14 +1,13 @@
 import {Then} from "@badeball/cypress-cucumber-preprocessor";
 
 Then(/^the user opens the warp menu$/, function () {
-    cy.get('*[class^=" warp-menu-column-toggle"]').children('*[id^="warp-menu-warpbtn"]').click();
+    cy.get("#warp-menu-shadow-host").shadow().find("#warp-toggle").click({force: true});
 });
 
 Then(/^the user checks link corresponding to the static page$/, function () {
-    cy.get('*[class^=" warp-menu-shift-container"]')
-        .children('*[class^=" warp-menu-category-list"]')
-        .contains(Cypress.env('nameOfStaticPageLinkInWarpMenu'))
-        .should('have.attr', 'target', '_top');
+    cy.get("#warp-menu-shadow-host").shadow().find(`a[role=menuitem][href="${Cypress.env('staticPagePath')}"]`)
+        .should('have.attr', 'target', '_top')
+        .contains(`${Cypress.env('nameOfStaticPageLinkInWarpMenu')}`);
 });
 
 Then("a static HTML page gets displayed", function () {

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -53,11 +53,15 @@ function configureMaintenanceModeSite() {
   doguctl config --remove maintenance || true
 }
 
+# Templates the /var/www/html/warp/add-warp-menu.js.tpl file with doguctl into /var/www/html/warp/add-warp-menu.js.
+# Adds the dogu-version to asset-urls for cache busting.
 # Configures the warp menu script as the menu.json gets mounted from a configmap into "/var/www/html/warp/menu"
 # instead of "/var/www/html/warp". This is a special constraints when mounting config maps. Mounting the warp menu
 # json directly into the warp folder would directly delete other files in the warp folder, including the warp.js script.
-function configureWarpMenuJson() {
+function configureWarpMenu() {
   log "Configure warp menu..."
+
+  doguctl template "/var/www/html/warp/add-warp-menu.js.tpl" "/var/www/html/warp/add-warp-menu.js"
 
   # Replace /warp/menu.json with /warp/menu/menu.json
   sed -i "s|/warp/menu.json|/warp/menu/menu.json|g" /var/www/html/warp/warp.js
@@ -111,7 +115,7 @@ function startNginx() {
 # make the script only run when executed, not when sourced from bats tests.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   printCloudoguLogo
-  configureWarpMenuJson
+  configureWarpMenu
   configureDefaultDogu
   configureCustomHtmlContent
   configureLogLevel

--- a/resources/var/www/html/warp/add-warp-menu.js
+++ b/resources/var/www/html/warp/add-warp-menu.js
@@ -1,9 +1,0 @@
-const addWarpMenu = function(){
-    var s = document.createElement("script");
-    s.type = "text/javascript";
-    s.src = "/warp/warp.js";
-    var x = document.getElementsByTagName("script")[0];
-    x.parentNode.insertBefore(s, x);
-}
-
-addWarpMenu();

--- a/resources/var/www/html/warp/add-warp-menu.js.tpl
+++ b/resources/var/www/html/warp/add-warp-menu.js.tpl
@@ -1,0 +1,17 @@
+const addWarpMenu = function(){
+    const warpScript = document.createElement("script");
+    warpScript.type = "text/javascript";
+    // Update this version whenever warp menu is updated
+    warpScript.src = "/warp/warp.js?nginx={{ .Env.Get "VERSION"}}";
+
+    const urlScript = document.createElement("script");
+    // This variable is used inside the warp menu script
+    // Update this version whenever warp menu is updated
+    urlScript.innerHTML = 'const cesWarpMenuWarpCssUrl = "/warp/warp.css?nginx={{ .Env.Get "VERSION"}}";';
+
+    const firstScriptTag = document.getElementsByTagName("script")[0];
+    firstScriptTag.parentNode.insertBefore(urlScript, firstScriptTag);
+    firstScriptTag.parentNode.insertBefore(warpScript, firstScriptTag);
+}
+
+addWarpMenu();


### PR DESCRIPTION
Make static asset urls dependent of the current dogu-version to invalidate caches


closes #21 